### PR TITLE
terraformを使用して予算アラートを追加する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.terraform/*
+

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.97.0"
+  constraints = "5.97.0"
+  hashes = [
+    "h1:953uFkvlqGOHtO6j+aeJELqmwI5z7uV28TnkKYy6pSA=",
+    "zh:02790ad98b767d8f24d28e8be623f348bcb45590205708334d52de2fb14f5a95",
+    "zh:088b4398a161e45762dc28784fcc41c4fa95bd6549cb708b82de577f2d39ffc7",
+    "zh:0c381a457b7af391c43fc0167919443f6105ad2702bde4d02ddea9fd7c9d3539",
+    "zh:1a4b57a5043dcca64d8b8bae8b30ef4f6b98ed2144f792f39c4e816d3f1e2c56",
+    "zh:1bf00a67f39e67664337bde065180d41d952242801ebcd1c777061d4ffaa1cc1",
+    "zh:24c549f53d6bd022af31426d3e78f21264d8a72409821669e7fd41966ae68b2b",
+    "zh:3abda50bbddb35d86081fe39522e995280aea7f004582c4af22112c03ac8b375",
+    "zh:7388ed7f21ce2eb46bd9066626ce5f3e2a5705f67f643acce8ae71972f66eaf6",
+    "zh:96740f2ff94e5df2b2d29a5035a1a1026fe821f61712b2099b224fb2c2277663",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f399f8e8683a3a3a6d63a41c7c3a5a5f266eedef40ea69eba75bacf03699879",
+    "zh:bcf2b288d4706ebd198f75d2159663d657535483331107f2cdef381f10688baf",
+    "zh:cc76c8a9fc3bad05a8779c1f80fe8c388734f1ec1dd0affa863343490527b466",
+    "zh:de4359cf1b057bfe7a563be93829ec64bf72e7a2b85a72d075238081ef5eb1db",
+    "zh:e208fa77051a1f9fa1eff6c5c58aabdcab0de1695b97cdea7b8dd81df3e0ed73",
+  ]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,26 @@
+resource "aws_budgets_budget" "monthly_budget" {
+  name         = "monthly-budget"
+  budget_type  = "COST"
+  limit_amount = "5"
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 5
+    threshold_type             = "ABSOLUTE_VALUE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = ["takuma.shishido0614@gmail.com"]
+    subscriber_sns_topic_arns  = [aws_sns_topic.budget_alerts.arn]
+  }
+}
+
+resource "aws_sns_topic" "budget_alerts" {
+  name = "budget-alerts"
+}
+
+resource "aws_sns_topic_subscription" "email_subscription" {
+  topic_arn = aws_sns_topic.budget_alerts.arn
+  protocol  = "email"
+  endpoint  = "takuma.shishido0614@gmail.com"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_version = "1.12.1"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.97.0"
+    }
+  }
+
+  backend "s3" {
+    bucket         = "kdg-aws-2025-takuma-shishido"
+    key            = "tfstate/aws.tfstate"
+    region         = "ap-northeast-1"
+    encrypt        = true
+  }
+}
+
+provider "aws" {
+  region  = "ap-northeast-1"
+}
+


### PR DESCRIPTION
## なぜやるか
- awsの予定外の出費を出さないようにするため

## なにをやったのか
- 月毎のコストが5ドル以上かかるとアラートが飛ぶようにmain.tfの追加

## 動作確認の手順
```shell
terraform init
terraform plan
terraform apply
```

# 画像
<img width="1298" alt="スクリーンショット 2025-06-07 13 56 47" src="https://github.com/user-attachments/assets/154cb28f-04bf-411c-8aa1-a9e091071335" />
<img width="1276" alt="スクリーンショット 2025-06-07 13 57 09" src="https://github.com/user-attachments/assets/b41007d4-b113-4a1d-9db7-1a0716da323c" />
<img width="1275" alt="スクリーンショット 2025-06-07 13 57 45" src="https://github.com/user-attachments/assets/eefe0864-7175-431a-9cb3-2a1b7c66639a" />
